### PR TITLE
docs: bump version to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library wraps the following libraries,
 ## Installation
 
 ```sh
-npm install --save git+https://github.com/emoto-kc-ak/react-native-mqtt-client.git#v0.1.0
+npm install --save git+https://github.com/emoto-kc-ak/react-native-mqtt-client.git#v0.1.1
 ```
 
 ## Usage


### PR DESCRIPTION
- The installation command is updated to install the latest version (0.1.1). The version is not tagged yet though.